### PR TITLE
Add all of TinyMCE's Editor events as propTypes

### DIFF
--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -53,7 +53,10 @@ var TinyMCE = React.createClass({
       EVENTS.forEach(function (event, index) {
         var handler = self.props[HANDLER_NAMES[index]];
         if (typeof handler !== 'function') return;
-        editor.on(event, handler);
+        editor.on(event, function(e) {
+          // native DOM events don't have access to the editor so we pass it here
+          handler(e, editor);
+        });
       });
     };
 

--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -3,31 +3,36 @@ var DOM = React.DOM;
 var uuid = require('../helpers/uuid');
 var uc_first = require('../helpers/uc_first');
 
+// Include all of the Native DOM and custom events from:
+// https://github.com/tinymce/tinymce/blob/master/tools/docs/tinymce.Editor.js#L5-L12
 var EVENTS = [
-  'activate', 'blur', 'change', 'deactivate', 'focus', 'hide',
-  'init', 'redo', 'remove', 'reset', 'show', 'submit', 'undo'
+  'focusin', 'focusout', 'click', 'dblclick', 'mousedown', 'mouseup',
+  'mousemove', 'mouseover', 'beforepaste', 'paste', 'cut', 'copy',
+  'selectionchange', 'mouseout', 'mouseenter', 'mouseleave', 'keydown',
+  'keypress', 'keyup', 'contextmenu', 'dragend', 'dragover', 'draggesture',
+  'dragdrop', 'drop', 'drag', 'BeforeRenderUI', 'SetAttrib', 'PreInit',
+  'PostRender', 'init', 'deactivate', 'activate', 'NodeChange',
+  'BeforeExecCommand', 'ExecCommand', 'show', 'hide', 'ProgressState',
+  'LoadContent', 'SaveContent', 'BeforeSetContent', 'SetContent',
+  'BeforeGetContent', 'GetContent', 'VisualAid', 'remove', 'submit', 'reset',
+  'BeforeAddUndo', 'AddUndo', 'change', 'undo', 'redo', 'ClearUndos',
+  'ObjectSelected', 'ObjectResizeStart', 'ObjectResized', 'PreProcess',
+  'PostProcess', 'focus', 'blur'
 ];
 
-module.exports = React.createClass({
+// Note: because the capitalization of the events is weird, we're going to get
+// some inconsistently-named handlers, for example compare:
+// 'onMouseleave' and 'onNodeChange'
+var HANDLER_NAMES = EVENTS.map(function(event) {
+  return 'on' + uc_first(event);
+});
+
+var TinyMCE = React.createClass({
   displayName: 'TinyMCE',
 
   propTypes: {
     config: React.PropTypes.object,
     content: React.PropTypes.string,
-
-    onActivate: React.PropTypes.func,
-    onBlur: React.PropTypes.func,
-    onChange: React.PropTypes.func,
-    onDeactivate: React.PropTypes.func,
-    onFocus: React.PropTypes.func,
-    onHide: React.PropTypes.func,
-    onInit: React.PropTypes.func,
-    onRedo: React.PropTypes.func,
-    onRemove: React.PropTypes.func,
-    onReset: React.PropTypes.func,
-    onShow: React.PropTypes.func,
-    onSubmit: React.PropTypes.func,
-    onUndo: React.PropTypes.func
   },
 
   getDefaultProps: function () {
@@ -45,13 +50,10 @@ module.exports = React.createClass({
     var self = this;
     this.props.config.selector = '#' + this.id;
     this.props.config.setup = function (editor) {
-      EVENTS.forEach(function (event) {
-        editor.on(event, function (e) {
-          var handler = self.props['on' + uc_first(event)];
-          if (typeof handler === 'function') {
-            handler(e);
-          }
-        });
+      EVENTS.forEach(function (event, index) {
+        var handler = self.props[HANDLER_NAMES[index]];
+        if (typeof handler !== 'function') return;
+        editor.on(event, handler);
       });
     };
 
@@ -69,3 +71,10 @@ module.exports = React.createClass({
     });
   }
 });
+
+//add handler propTypes
+HANDLER_NAMES.forEach(function (name) {
+  TinyMCE.propTypes[name] = React.PropTypes.func;
+});
+
+module.exports = TinyMCE;


### PR DESCRIPTION
I found I needed some event handlers that weren't included in the default list so I decided to just add all possible events.

This also only adds a handler to the editor if it's defined in the props - previously a handler was added for every event in `EVENTS` (though they would just be no-ops if the handler wasn't defined). 

Let me know what you think!