### PR TITLE
use EditorManager to remove instances

### DIFF
--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -91,7 +91,7 @@ var TinyMCE = React.createClass({
   },
 
   _remove: function () {
-    tinymce.remove(this.id);
+    tinymce.EditorManager.execCommand("mceRemoveEditor", true, this.id);
     this._isInit = false;
   },
 


### PR DESCRIPTION
I think `tinymce.remove(id)` was the api for v3 - it didn't appear to be working in our app which was causing some weirdness with event handlers. v4 moved remove to the `EditorManager` object which is what I used here. In our app this change keeps `tinymce.editors.length` to 1.