### PR TITLE
address stale content when re-initing

### DIFF
--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -57,7 +57,7 @@ var TinyMCE = React.createClass({
 
   componentWillReceiveProps: function (nextProps) {
     if (!isEqual(this.props.config, nextProps.config)) {
-      this._init(nextProps.config);
+      this._init(nextProps.config, nextProps.content);
     }
   },
 
@@ -68,7 +68,7 @@ var TinyMCE = React.createClass({
     );
   },
 
-  _init: function (config) {
+  _init: function (config, content) {
     if (this._isInit) {
       this._remove();
     }
@@ -84,6 +84,13 @@ var TinyMCE = React.createClass({
           handler(e, editor);
         });
       });
+      // need to set content here because the textarea will still have the
+      // old `this.props.content`
+      if (content) {
+        editor.on('init', function() {
+          editor.setContent(content);
+        });
+      }
     };
 
     tinymce.init(config);


### PR DESCRIPTION
Re-initing happens before `render` so manually calling `setContent` on the editor is necessary so that you get the fresh content in the editor.