### PR TITLE
Hide the textarea before initialization

### DIFF
--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -98,6 +98,9 @@ var TinyMCE = React.createClass({
     };
 
     tinymce.init(config);
+
+    self.getDOMNode().style.hidden = "";
+
     this._isInit = true;
   },
 

--- a/lib/components/TinyMCE.js
+++ b/lib/components/TinyMCE.js
@@ -74,6 +74,10 @@ var TinyMCE = React.createClass({
     }
 
     var self = this;
+
+    //hide the textarea that is me so that no one sees it
+    self.getDOMNode().style.hidden = "hidden";
+
     config.selector = '#' + this.id;
     config.setup = function (editor) {
       EVENTS.forEach(function (event, index) {


### PR DESCRIPTION
In some cases the textarea that the tinyMCE editor replaces is visible
before initialization is complete. Adding visible: hidden removes it
visually before initialization happens and allows everything else to
go smoothly.